### PR TITLE
Update bank statement tests to use new york time zone (vs -5 offset)

### DIFF
--- a/src/test/scala/org/vvcephei/scalaofx/lib/model/response/BankStatementTest.scala
+++ b/src/test/scala/org/vvcephei/scalaofx/lib/model/response/BankStatementTest.scala
@@ -1,6 +1,6 @@
 package org.vvcephei.scalaofx.lib.model.response
 
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.FunSuite
 import org.vvcephei.scalaofx.client.SourceClient
 import org.vvcephei.scalaofx.lib.model.AccountType
@@ -8,7 +8,9 @@ import org.vvcephei.scalaofx.lib.model.AccountType
 import scala.io.Source
 
 class BankStatementTest extends FunSuite {
+
   test("can parse bank statement") {
+    val newYorkTimeZone = DateTimeZone.forID("America/New_York");
     val statements: BankStatementResponse = SourceClient.bankStatements(Source.fromString(Data.bankStatement))
     assert(statements.errors.isEmpty)
     assert(statements.statements.length === 1)
@@ -17,12 +19,12 @@ class BankStatementTest extends FunSuite {
     assert(statements.statements.head.account.`type` === Some(AccountType.CHECKING))
     assert(statements.statements.head.currency === "USD")
     assert(statements.statements.head.availableBalance === None)
-    assert(statements.statements.head.startTime === Some(new DateTime("2014-05-01T12:00:00.000-05:00")))
-    assert(statements.statements.head.endTime === Some(new DateTime("2014-07-08T12:00:00.000-05:00")))
+    assert(statements.statements.head.startTime === Some(new DateTime("2014-05-01T12:00:00.000", newYorkTimeZone)))
+    assert(statements.statements.head.endTime === Some(new DateTime("2014-07-08T12:00:00.000", newYorkTimeZone)))
     assert(statements.statements.head.ledgerBalance === 100.10)
     assert(statements.statements.head.transactions.length === 1)
     assert(statements.statements.head.transactions.head.`type` === TransactionType.DEBIT)
-    assert(statements.statements.head.transactions.head.posted === new DateTime("2014-07-07T12:00:00.000-05:00"))
+    assert(statements.statements.head.transactions.head.posted === new DateTime("2014-07-07T12:00:00.000", newYorkTimeZone))
     assert(statements.statements.head.transactions.head.amount === -0.84)
     assert(statements.statements.head.transactions.head.memo === None)
     assert(statements.statements.head.transactions.head.name === Some("Trans Name"))


### PR DESCRIPTION
- Fixes #1
  
  [info] - can parse bank statement **\* FAILED ***
  [info]   Some(2014-05-01T12:00:00.000-04:00) did not equal Some(2014-05-01T13:00:00.000-04:00) (BankStatementTest.scala:20)
